### PR TITLE
Add Volume mount check and fix docker detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ Simple user-facing command line interface (CLI) for installing and running the G
 
 ## Introduction
 This Python package is provided as a method to install and run the Gigantum application, locally on your computer. It provides a
-simple command line interface to install, update, start, and stop the application. Currently this is only targeting
-alpha testers and not generally available yet.
+simple command line interface to install, update, start, and stop the application. 
+
+**Currently this is package only targeting alpha testers and not generally available yet and you must be granted
+access to the Gigantum Docker Image**
 
 If you encounter any issues or have any questions, do not hesitate in contacting Gigantum for help. 
 
@@ -26,8 +28,9 @@ If you encounter any issues or have any questions, do not hesitate in contacting
     Docker [website](https://www.docker.com/community-edition#/download)
     
     - Windows:
-        - **NOTE: Windows is temporarily not supported. Fixes are coming in the next release**
+        - **NOTE: Windows is only partially supported. Additional testing is still required due to challengs with Docker on Windows**
         - Requires Microsoft Windows 10 Professional or Enterprise 64-bit
+        - Requires Docker CE Stable
         - [https://store.docker.com/editions/community/docker-ce-desktop-windows](https://store.docker.com/editions/community/docker-ce-desktop-windows)
     
     - Mac:
@@ -118,12 +121,6 @@ Usage of the CLI then becomes:
     - **Run this command after installing the CLI for the first time.**
     - Depending on your bandwidth, installing for the first time can take a while as the Docker Image layers are downloaded.
     - This command installs the Gigantum application Docker Image for the first time and configures your working directory.
-    
-        The Gigantum working directory changes based on your operating system:
-        
-        - Windows: `C:\\Users\<username>\gigantum`
-        - OSX: `/Users/<username>/gigantum`
-        - Linux: `/home/<username>/gigantum`
 
 - `update`
     - This command updates an existing installation to the latest version of the application
@@ -135,6 +132,8 @@ Usage of the CLI then becomes:
     - This command starts the Gigantum application
     - Once started, the application User Inteface is available at [http://localhost:10000](http://localhost:10000)
     - Currently, any running Jupyter instance will be available at [http://localhost:8888](http://localhost:8888) once launched
+    - **Once you create your first LabBook, check your Gigantum working directory for LabBook to make sure everything is
+    configured properly. This directory is organized by
     
 - `stop`
     - This command currently stops the Gigantum Application and *ALL* Docker containers on your computer
@@ -144,6 +143,28 @@ Usage of the CLI then becomes:
     
 ## Usage
 
+### Gigantum Working Directory
+
+The Gigantum working directory is where all your work is stored on your local filesystem. You can interact directly
+with this directory if you'd like, but it is recommended to use the Gigantum UI as it ensures all activity is properly
+recorded.
+
+The Gigantum working directory location changes based on your operating system:
+        
+    - Windows: C:\\Users\<username>\gigantum
+    - OSX: /Users/<username>/gigantum
+    - Linux: /home/<username>/gigantum
+    
+This directory follows a standard directory structure that organizes content by user and namespace. A namespace is the 
+"owner" of a LabBook, and typically the creator. The working directory is organized as illustrated below:
+
+    - ~/gigantum
+        - <logged in user's username>
+            - <namespace>
+                - labbooks
+                    - <labbook name>
+        
+        
 ### User Account
 To use the Gigantum application you must have a Gigantum user account. When you run the application for the first time, you can register. 
 
@@ -180,18 +201,36 @@ After everything is installed, a typical usage would follow a workflow like this
 
 ### Sharing 
 
-Currently, sharing is limited to an export/import workflow. If you want to share a LabBook with someone, click on the Export button in the LabBook Overview page.
+There are two ways to share LabBooks; export/import and remote repository-based sharing. 
 
-This will download a `.lbk` archive file to the `export` directory in your Gigantum working directory. You can then share this file with someone else.
+### Export/Import
+To export a LabBook, click on the the Export button in the LabBook Overview page.
 
-To import, simply drag-and-drop the `.lbk` file into the Import area in the LabBook Overview page. Note that if the file is large, import can take a little while.
+This will download a `.lbk` archive file to the `export` directory in your Gigantum working directory. 
+You can then share this file with someone else or archive it.
 
-You cannot duplicate LabBooks. If you want to import a LabBook "on top" of an existing LabBook, currently you'll have to rename the original LabBook before Import.
+To import, simply drag-and-drop the `.lbk` file into the Import area in the LabBook Overview page. 
+Note that if the file is large, import can take a little while. Also, importing a LabBook detaches it from the source,
+so it will always import into the currently logged in user's namespace.
+
+You cannot duplicate LabBooks. If you want to import a LabBook "on top" of an existing LabBook, currently you'll 
+have to rename the original LabBook before Import.
+
+### Sharing via remote repository
+Currently, only sharing to the Gigantum cloud is supported.
+
+To share via a remote repository, simply click the "publish" button in the LabBook action menu, located in the top right
+corner of an opened LabBook. Once published, you'll receive a link that you can share with other users.
+
+By default all LabBooks are private. Click on the `collaborators` button in the LabBook action menu. Enter the Gigantum
+username of any users you wish to collaborate with. They can then enter the link returned by the publish operation into
+the new LabBook wizard to download and open your LabBook.
     
+
 ## Providing Feedback
 
 If you encounter any issues using the Gigantum CLI, submit them to this [GitHub repository issues page](https://github.com/gigantum/gigantum-cli/issues).
 
-If you encounter any issues or have any feedback while using the the Gigantum Application, use the feedback command to open the feedback form.
+If you encounter any issues or have any feedback while using the the Gigantum Application, use the `gigantum feedback` command to open the feedback form.
 
 For urgent issues, contact Gigantum.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ Simple user-facing command line interface (CLI) for installing and running the G
 This Python package is provided as a method to install and run the Gigantum application, locally on your computer. It provides a
 simple command line interface to install, update, start, and stop the application. 
 
-**Currently this is package only targeting alpha testers and not generally available yet and you must be granted
-access to the Gigantum Docker Image**
+**Currently this is package only targeting alpha testers and not generally available yet. You must be granted access to the Gigantum Docker Image to install locally**
 
 If you encounter any issues or have any questions, do not hesitate in contacting Gigantum for help. 
 
@@ -28,7 +27,7 @@ If you encounter any issues or have any questions, do not hesitate in contacting
     Docker [website](https://www.docker.com/community-edition#/download)
     
     - Windows:
-        - **NOTE: Windows is only partially supported. Additional testing is still required due to challengs with Docker on Windows**
+        - **NOTE: Windows is only partially supported. Additional testing is still required due to recent changes with Docker on Windows**
         - Requires Microsoft Windows 10 Professional or Enterprise 64-bit
         - Requires Docker CE Stable
         - [https://store.docker.com/editions/community/docker-ce-desktop-windows](https://store.docker.com/editions/community/docker-ce-desktop-windows)
@@ -71,7 +70,9 @@ If you encounter any issues or have any questions, do not hesitate in contacting
     Since the Gigantum application is still a closed alpha, you must be granted access to the Docker image. To do so, 
     first create a free DockerHub account at [https://hub.docker.com/](https://hub.docker.com/) and **send your username to Gigantum**.
     
-    Start your Docker application. Open the Docker menu by clicking on the app icon in your system tray or taskbar. Click on Sign-In in the Docker menu, and enter your DockerHub credentials.
+    - Start your Docker application. 
+    - Open the Docker menu by clicking on the app icon in your system tray or taskbar. 
+    - Click on Sign-In in the Docker menu, and enter your DockerHub credentials.
     
     ![sign in](docs/img/docker-signin.png)
     
@@ -83,12 +84,11 @@ If you encounter any issues or have any questions, do not hesitate in contacting
            
 ## Install the CLI
 
-This package is available for install via `pip`. It runs on Python 2 and 3 and supports Windows, OSX and Linux. Currently,
-Windows support is limited to Windows 10 Professional.
+This package is available for install via `pip`. It runs on Python 2 and 3 and supports Windows, OSX and Linux. 
 
-1. To isolate this installation from your system Python, it is often best to create a virtual environment first.
+1. To isolate this package from your system Python, it is often best to create a virtual environment first.
 This is not required, but recommended if you feel comfortable enough with Python. The Gigantum CLI installs a minimal set of 
-Python dependencies, so in general should be safe to simply install if preferred.
+Python dependencies, so in general it should be safe to simply install if preferred.
 
 	Using [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/):
 	
@@ -132,8 +132,7 @@ Usage of the CLI then becomes:
     - This command starts the Gigantum application
     - Once started, the application User Inteface is available at [http://localhost:10000](http://localhost:10000)
     - Currently, any running Jupyter instance will be available at [http://localhost:8888](http://localhost:8888) once launched
-    - **Once you create your first LabBook, check your Gigantum working directory for LabBook to make sure everything is
-    configured properly. This directory is organized by
+    - **Once you create your first LabBook, check your Gigantum working directory for LabBook to make sure everything is configured properly. See the `Gigantum Working Directory` section for more details.**
     
 - `stop`
     - This command currently stops the Gigantum Application and *ALL* Docker containers on your computer
@@ -151,24 +150,39 @@ recorded.
 
 The Gigantum working directory location changes based on your operating system:
         
-    - Windows: C:\\Users\<username>\gigantum
-    - OSX: /Users/<username>/gigantum
-    - Linux: /home/<username>/gigantum
+- **Windows**: `C:\\Users\<username>\gigantum`
+- **OSX**: `/Users/<username>/gigantum`
+- **Linux**: `/home/<username>/gigantum`
     
 This directory follows a standard directory structure that organizes content by user and namespace. A namespace is the 
 "owner" of a LabBook, and typically the creator. The working directory is organized as illustrated below:
 
-    - ~/gigantum
-        - <logged in user's username>
-            - <namespace>
-                - labbooks
-                    - <labbook name>
+```
+<Gigantum Working Directory>
+	|_ <logged in user's username>
+		|_ <namespace>
+   			|_ labbooks
+      			|_ <labbook name>
+```
+
+As an example, if the user `sarah` created 1 LabBook and downloaded 1 LabBook from the user `janet` the directory would look like this:
+
+```
+<Gigantum Working Directory>
+	|_ sarah
+		|_ sarah
+   			|_ labbooks
+      			|_ my-first-labbook
+		|_ janet
+   			|_ labbooks
+      			|_ initial-analysis-1
+```
         
         
 ### User Account
-To use the Gigantum application you must have a Gigantum user account. When you run the application for the first time, you can register. 
+To use the Gigantum application you must have a Gigantum user account. When you run the application for the first time you can register. 
 
-Note that you'll get an extra warning about granting the application access to your account when you sign in for the first time. This is an extra security measure that occurs because the app is running on localhost and not a verified domain and is expected.
+Note that you'll get an extra warning about granting the application access to your account when you sign in for the first time. This is an extra security measure that occurs because the app is running on localhost and not a verified domain. This is expected.
 
 Once you login, your user identity is cached locally. This lets you run the application when disconnected from the internet and without logging in again. If you logout, you will not be able to use the application again until you have internet access and can re-authenticate.
 
@@ -210,6 +224,7 @@ This will download a `.lbk` archive file to the `export` directory in your Gigan
 You can then share this file with someone else or archive it.
 
 To import, simply drag-and-drop the `.lbk` file into the Import area in the LabBook Overview page. 
+
 Note that if the file is large, import can take a little while. Also, importing a LabBook detaches it from the source,
 so it will always import into the currently logged in user's namespace.
 

--- a/gigantumcli/__init__.py
+++ b/gigantumcli/__init__.py
@@ -19,5 +19,5 @@
 # SOFTWARE.
 
 # Gigantum CLI Version
-__version__ = "0.2"
+__version__ = "0.3"
 

--- a/gigantumcli/actions.py
+++ b/gigantumcli/actions.py
@@ -31,6 +31,10 @@ from gigantumcli.utilities import ask_question, ExitCLI
 
 def install():
     """Method to install the Gigantum Image"""
+    # Make sure user is not root
+    if getpass.getuser() == 'root':
+        raise ExitCLI("Do not run `gigantum start` as root.")
+
     docker = DockerInterface()
 
     try:
@@ -65,6 +69,10 @@ def update(tag=None):
     Returns:
         None
     """
+    # Make sure user is not root
+    if getpass.getuser() == 'root':
+        raise ExitCLI("Do not run `gigantum start` as root.")
+
     docker = DockerInterface()
 
     try:

--- a/gigantumcli/actions.py
+++ b/gigantumcli/actions.py
@@ -26,14 +26,14 @@ import getpass
 
 from gigantumcli.dockerinterface import DockerInterface
 from gigantumcli.changelog import ChangeLog
-from gigantumcli.utilities import ask_question, ExitCLI
+from gigantumcli.utilities import ask_question, ExitCLI, is_running_as_admin
 
 
 def install():
     """Method to install the Gigantum Image"""
     # Make sure user is not root
-    if getpass.getuser() == 'root':
-        raise ExitCLI("Do not run `gigantum start` as root.")
+    if is_running_as_admin():
+        raise ExitCLI("Do not run `gigantum install` as root.")
 
     docker = DockerInterface()
 
@@ -70,8 +70,8 @@ def update(tag=None):
         None
     """
     # Make sure user is not root
-    if getpass.getuser() == 'root':
-        raise ExitCLI("Do not run `gigantum start` as root.")
+    if is_running_as_admin():
+        raise ExitCLI("Do not run `gigantum update` as root.")
 
     docker = DockerInterface()
 
@@ -137,7 +137,7 @@ def start(tag=None):
     docker = DockerInterface()
 
     # Make sure user is not root
-    if getpass.getuser() == 'root':
+    if is_running_as_admin():
         raise ExitCLI("Do not run `gigantum start` as root.")
 
     # Check if working dir exists

--- a/gigantumcli/actions.py
+++ b/gigantumcli/actions.py
@@ -22,6 +22,7 @@ from docker.errors import APIError, ImageNotFound, NotFound
 import os
 import webbrowser
 import time
+import getpass
 
 from gigantumcli.dockerinterface import DockerInterface
 from gigantumcli.changelog import ChangeLog
@@ -123,11 +124,16 @@ def start(tag=None):
     Returns:
         None 
     """
+    print("Verifying Docker is available...")
     # Check if Docker is running
     docker = DockerInterface()
 
+    # Make sure user is not root
+    if getpass.getuser() == 'root':
+        raise ExitCLI("Do not run `gigantum start` as root.")
+
     # Check if working dir exists
-    working_dir = os.path.expanduser("~/gigantum")
+    working_dir = os.path.join(os.path.expanduser("~"), "gigantum")
     if not os.path.exists(working_dir):
         os.makedirs(working_dir)
 
@@ -148,7 +154,6 @@ def start(tag=None):
         pass
 
     # Start
-    working_dir = os.path.join(os.path.expanduser("~"), "gigantum")
     port_mapping = {'10000/tcp': 10000,
                     '10001/tcp': 10001}
 
@@ -173,15 +178,41 @@ def start(tag=None):
         volume_mapping[working_dir] = {'bind': '/mnt/gigantum', 'mode': 'cached'}
         volume_mapping['/var/run/docker.sock'] = {'bind': '/var/run/docker.sock', 'mode': 'rw'}
 
-    docker.client.containers.run(image="gigantum/labmanager:{}".format(tag),
-                                 detach=True,
-                                 name="gigantum-labmanager",
-                                 init=True,
-                                 ports=port_mapping,
-                                 volumes=volume_mapping,
-                                 environment=environment_mapping)
-    print("Starting...")
-    time.sleep(5)
+    container = docker.client.containers.run(image="gigantum/labmanager:{}".format(tag),
+                                             detach=True,
+                                             name="gigantum-labmanager",
+                                             init=True,
+                                             ports=port_mapping,
+                                             volumes=volume_mapping,
+                                             environment=environment_mapping)
+    print("Starting, please wait...")
+    time.sleep(3)
+
+    # Make sure volumes have mounted properly, by checking for the log file for up to 30 seconds
+    success = False
+    for _ in range(30):
+        if os.path.exists(os.path.join(working_dir, '.labmanager', 'logs', 'labmanager.log')):
+            success = True
+            break
+
+        # Sleep for 1 sec and increment counter
+        time.sleep(1)
+
+    if not success:
+        msg = "\n\nWorking directory failed to mount! Have you granted Docker access to your user directory?"
+        msg = msg + " \nIn both Docker for Mac and Docker for Windows this should be shared by default, but may require"
+        msg = msg + " a confirmation from the user."
+        msg = msg + "\n\nRun `gigantum stop`, verify your OS and Docker versions are supported, the allowed Docker"
+        msg = msg + " volume share locations include `{}`, and try again.".format(working_dir)
+        msg = msg + "\n\nIf this problem persists, contact support."
+
+        # Stop and remove the container
+        container.stop()
+        docker.client.api.remove_container(container.id)
+
+        raise ExitCLI(msg)
+
+    # If here, things look OK. Start browser
     webbrowser.open_new("http://localhost:10000")
 
 

--- a/gigantumcli/utilities.py
+++ b/gigantumcli/utilities.py
@@ -19,6 +19,8 @@
 # SOFTWARE.
 from __future__ import print_function
 from six.moves import input
+import ctypes
+import os
 
 
 class ExitCLI(Exception):
@@ -44,3 +46,17 @@ def ask_question(question):
             return valid_response[choice]
         else:
             print("Please respond with 'yes' or 'no' (or 'y' or 'n').\n")
+
+
+def is_running_as_admin():
+    """Method to check if the python script is running as an administrator
+
+    Returns:
+        bool
+    """
+    try:
+        is_admin = os.getuid() == 0
+    except AttributeError:
+        is_admin = ctypes.windll.shell32.IsUserAnAdmin()
+
+    return is_admin


### PR DESCRIPTION
- Added a check for the log file on `gigantum start`. This ensures that the volume mounts are working properly and will prevent a user from loosing work if they run Gigantum without mounts allowed by Docker.
- Added checks for root user before running commands
- Fixed some checks for Docker to be running that were not correct
- Updated readme