### PR TITLE
gig1026: update start/stop commands for more robust behavior

### DIFF
--- a/gigantumcli/__init__.py
+++ b/gigantumcli/__init__.py
@@ -19,5 +19,5 @@
 # SOFTWARE.
 
 # Gigantum CLI Version
-__version__ = "0.5"
+__version__ = "0.6"
 


### PR DESCRIPTION
- Update start command to check for running API and launch browser
- update start command to check for stopped container and remove automatically
- Update start command to wait for API to be up before launching browser
- Update stop to only stop and remove gigantum managed containers