### PR TITLE
Update docker to 3.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.18.4
-docker==2.5.1
+docker==3.0.1
 six==1.11.0


### PR DESCRIPTION
3.0.1 is the new fresh code, but more importantly includes a dependency for pypiwin32, which is necessary for the package to work on windows.

Trivial, so please feel free to merge at time of approval.