### PR TITLE
Fix container prune behavior (#37)

### DIFF
--- a/gigantumcli/__init__.py
+++ b/gigantumcli/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 FlashX, LLC
+# Copyright (c) 2018 FlashX, LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +19,4 @@
 # SOFTWARE.
 
 # Gigantum CLI Version
-__version__ = "0.13"
+__version__ = "0.14"

--- a/gigantumcli/__init__.py
+++ b/gigantumcli/__init__.py
@@ -1,22 +1,3 @@
-# Copyright (c) 2018 FlashX, LLC
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
 
 # Gigantum CLI Version
 __version__ = "0.14"

--- a/gigantumcli/actions.py
+++ b/gigantumcli/actions.py
@@ -85,7 +85,7 @@ def install(image_name):
         try:
             # Check to see if the image has already been pulled
             docker.client.images.get(image_name)
-            raise ExitCLI("** Gigantum Client already installed. Run `gigantum update` instead.")
+            raise ExitCLI("** Gigantum Client image already installed. Run `gigantum update` instead.")
 
         except ImageNotFound:
             # Pull for the first time
@@ -132,7 +132,7 @@ def update(image_name, tag=None):
                 try:
                     current_image = docker.client.images.get("{}:latest".format(image_name))
                 except ImageNotFound:
-                    raise ExitCLI("Gigantum Client not yet installed. Run 'gigantum install' first.")
+                    raise ExitCLI("Gigantum Client image not yet installed. Run 'gigantum install' first.")
                 short_id = current_image.short_id.split(':')[1]
 
                 # Check if there is an update available
@@ -239,7 +239,7 @@ def start(image_name, tag=None):
     try:
         docker.client.images.get("{}:{}".format(image_name, tag))
     except ImageNotFound:
-        raise ExitCLI("Gigantum Client container not found. Did you run `gigantum install` yet?")
+        raise ExitCLI("Gigantum Client image not found. Did you run `gigantum install` yet?")
 
     # Check to see if already running
     try:

--- a/gigantumcli/actions.py
+++ b/gigantumcli/actions.py
@@ -32,13 +32,10 @@ from gigantumcli.utilities import ask_question, ExitCLI, is_running_as_admin
 
 
 def _cleanup_containers() -> None:
-    """
-
-    Args:
-        stop:
+    """Method to clean up gigantum managed containers, stopping if needed.
 
     Returns:
-
+        None
     """
     docker = DockerInterface()
 

--- a/gigantumcli/actions.py
+++ b/gigantumcli/actions.py
@@ -34,6 +34,8 @@ from gigantumcli.utilities import ask_question, ExitCLI, is_running_as_admin
 def _cleanup_containers() -> None:
     """Method to clean up gigantum managed containers, stopping if needed.
 
+    Note: this method is the only place removal of containers should occur
+
     Returns:
         None
     """

--- a/gigantumcli/cli.py
+++ b/gigantumcli/cli.py
@@ -24,18 +24,18 @@ import sys
 
 def main():
     # Setup supported components and commands
-    actions = {"install": "Install the Gigantum application Docker Image",
-               "update": "Update the Gigantum application Docker Image",
-               "start": "Start the application",
-               "stop": "Stop the application",
-               "feedback": "Open a web page to provide feedback to Gigantum"
+    actions = {"install": "Install the Gigantum Client Docker Image",
+               "update": "Update the Gigantum Client Docker Image",
+               "start": "Start the Client",
+               "stop": "Stop the Client",
+               "feedback": "Open a web page to provide feedback"
                }
 
     help_str = ""
     for action in actions:
         help_str = "{}  - {}: {}\n".format(help_str, action, actions[action])
 
-    description_str = "Command Line Interface for the Gigantum Local Platform (Alpha)\n\n"
+    description_str = "Command Line Interface for the local Gigantum Client application\n\n"
     description_str = description_str + "The following actions are supported:\n\n{}".format(help_str)
 
     parser = argparse.ArgumentParser(description=description_str,
@@ -49,7 +49,7 @@ def main():
     parser.add_argument("--edge", "-e",
                         action='store_true',
                         help="Optional flag indicating if the edge version should be used."
-                             " Applicable to install, update, and start commands")
+                             " Applicable to install, update, and start commands. You must have access to this image.")
     parser.add_argument("action", help="Action to perform")
 
     args = parser.parse_args()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests==2.18.4
+requests==2.21.0
 docker==3.0.1
 six==1.11.0


### PR DESCRIPTION
This PR fixes the container prune behavior during `start` and `stop` commands. The CLI should only mess with Gigantum managed containers in case the user uses Docker for other stuff locally. The CLI was running a `docker container prune` command after the normal clean up process. Additional minor clean up of messaging is in here as well.