### PR TITLE
#40: Add check for nvidia drivers on linux

### DIFF
--- a/gigantumcli/__init__.py
+++ b/gigantumcli/__init__.py
@@ -1,3 +1,3 @@
 
 # Gigantum CLI Version
-__version__ = "0.14"
+__version__ = "0.15"

--- a/gigantumcli/actions.py
+++ b/gigantumcli/actions.py
@@ -28,7 +28,7 @@ import uuid
 
 from gigantumcli.dockerinterface import DockerInterface
 from gigantumcli.changelog import ChangeLog
-from gigantumcli.utilities import ask_question, ExitCLI, is_running_as_admin
+from gigantumcli.utilities import ask_question, ExitCLI, is_running_as_admin, get_nvidia_driver_version
 
 
 def _cleanup_containers() -> None:
@@ -281,7 +281,8 @@ def start(image_name, tag=None):
     else:
         # For anything else, just use default mode.
         environment_mapping = {'HOST_WORK_DIR': working_dir,
-                               'LOCAL_USER_ID':  os.getuid()}
+                               'LOCAL_USER_ID':  os.getuid(),
+                               'NVIDIA_DRIVER_VERSION': get_nvidia_driver_version()}
         volume_mapping[working_dir] = {'bind': '/mnt/gigantum', 'mode': 'rw'}
 
     volume_mapping['/var/run/docker.sock'] = {'bind': '/var/run/docker.sock', 'mode': 'rw'}

--- a/gigantumcli/utilities.py
+++ b/gigantumcli/utilities.py
@@ -21,6 +21,9 @@ from __future__ import print_function
 from six.moves import input
 import ctypes
 import os
+import platform
+import subprocess
+import re
 
 
 class ExitCLI(Exception):
@@ -60,3 +63,16 @@ def is_running_as_admin():
         is_admin = ctypes.windll.shell32.IsUserAnAdmin()
 
     return is_admin
+
+
+def get_nvidia_driver_version() -> str:
+    driver_version = None
+    if platform.system() == 'Linux':
+        bash_command = "nvidia-smi --query-gpu=driver_version --format=csv,noheader"
+        process = subprocess.Popen(bash_command.split(), stdout=subprocess.PIPE)
+        output, error = process.communicate()
+        if not error:
+            m = re.match(r"([\d.]+)", output.decode())
+            if m:
+                driver_version = m.group(0)
+    return driver_version


### PR DESCRIPTION
This PR adds a check for NVIDIA driver version on linux. If the version is available, it sets the `NVIDIA_DRIVER_VERSION` environment variable, which will then invoke automatic GPU compatibility checks and nvidia-docker runtime use when launching project containers.

To test, be sure to use the `cudanew` branch of base-images and `launchgpu` branch of gigantum-client until everything is merged.