### PR TITLE
Add nvidia-smi lookup

### DIFF
--- a/gigantumcli/__init__.py
+++ b/gigantumcli/__init__.py
@@ -1,2 +1,2 @@
 # Gigantum CLI Version
-__version__ = "1.3.3"
+__version__ = "1.3.4"

--- a/gigantumcli/commands/start.py
+++ b/gigantumcli/commands/start.py
@@ -14,7 +14,7 @@ import click
 from gigantumcli.dockerinterface import DockerInterface
 from gigantumcli.commands.install import install
 from gigantumcli.config import ConfigOverrideFile
-from gigantumcli.utilities import ask_question, is_running_as_admin, get_nvidia_gpu_info
+from gigantumcli.utilities import ask_question, is_running_as_admin, get_nvidia_gpu_info, get_nvidia_smi_path
 
 # We can disable this because requests is just being used to verify API connectivity
 # and in a context where the client is running with HTTPS, the lookup still happens on
@@ -194,6 +194,13 @@ def start(ctx, edge: bool, timeout: int, tag: Optional[str] = None, port: int = 
         if driver_version:
             print(f"Detected {num_gpus} GPU(s) available for use.")
             environment_mapping['NVIDIA_NUM_GPUS'] = num_gpus
+
+            # Mount nvidia-smi as read-only
+            print("LOOKING UP NVIDIA SMI")
+            smi_path = get_nvidia_smi_path()
+            print(f"PATH: {smi_path}")
+            if smi_path:
+                environment_mapping['NVIDIA_SMI_PATH'] = smi_path
 
         volume_mapping[working_dir] = {'bind': '/mnt/gigantum', 'mode': 'rw'}
 

--- a/gigantumcli/commands/start.py
+++ b/gigantumcli/commands/start.py
@@ -195,10 +195,8 @@ def start(ctx, edge: bool, timeout: int, tag: Optional[str] = None, port: int = 
             print(f"Detected {num_gpus} GPU(s) available for use.")
             environment_mapping['NVIDIA_NUM_GPUS'] = num_gpus
 
-            # Mount nvidia-smi as read-only
-            print("LOOKING UP NVIDIA SMI")
+            # Mount nvidia-smi as read-only if present
             smi_path = get_nvidia_smi_path()
-            print(f"PATH: {smi_path}")
             if smi_path:
                 environment_mapping['NVIDIA_SMI_PATH'] = smi_path
 

--- a/gigantumcli/utilities.py
+++ b/gigantumcli/utilities.py
@@ -95,3 +95,27 @@ def get_nvidia_gpu_info() -> Tuple[Optional[str], int]:
         except FileNotFoundError:
             pass
     return driver_version, num_gpus
+
+
+def get_nvidia_smi_path() -> Optional[str]:
+    """
+
+    Returns:
+
+    """
+    nvidia_smi_path = None
+    if platform.system() == 'Linux':
+        print(f"Searching for nvidia-smi")
+        try:
+            process = subprocess.Popen(['which', 'nvidia-smi'], stdout=subprocess.PIPE)
+            output, error = process.communicate()
+            if not error:
+                result = output.decode().strip()
+                if result.endswith('nvidia-smi'):
+                    print(f"DETECTED NVIDIA_SMI: {result}")
+                    nvidia_smi_path = result
+        except:
+            # If we can't find nvidia-smi just continue on
+            pass
+
+    return nvidia_smi_path

--- a/gigantumcli/utilities.py
+++ b/gigantumcli/utilities.py
@@ -98,21 +98,22 @@ def get_nvidia_gpu_info() -> Tuple[Optional[str], int]:
 
 
 def get_nvidia_smi_path() -> Optional[str]:
-    """
+    """Function to look for the nvidia-smi binary
+
+    This is then provided to the Client and is used when launching GPU enabled projects with the "new" Docker
+    launch configuration that does not use the nvidia runtime.
 
     Returns:
-
+        absolute path to the nvidia-smi binary if it exists.
     """
     nvidia_smi_path = None
     if platform.system() == 'Linux':
-        print(f"Searching for nvidia-smi")
         try:
             process = subprocess.Popen(['which', 'nvidia-smi'], stdout=subprocess.PIPE)
             output, error = process.communicate()
             if not error:
                 result = output.decode().strip()
                 if result.endswith('nvidia-smi'):
-                    print(f"DETECTED NVIDIA_SMI: {result}")
                     nvidia_smi_path = result
         except:
             # If we can't find nvidia-smi just continue on


### PR DESCRIPTION
This small PR adds a step to look up the absolute path to the `nvidia-smi` binary on the host, and if present sets an environment variable that is used in the Client.

This is needed because when launching GPU enabled Projects in the "new" configuration where the nvidia runtime is NOT used, nvidia-smi is missing in the project container. The client will bind mount the binary from the host as read-only in this case, and typically it'll "just work".